### PR TITLE
Add OopsSec Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ A curated list of cyber security resources and tools.
 * [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) - Intentionally insecure web app for security training.
 * [OWASP WebGoat](https://owasp.org/www-project-webgoat/) - Deliberately insecure web application maintained by OWASP.
 * [OWASP Security Shepherd](https://owasp.org/www-project-security-shepherd/) - Training platform for learning and practicing application security.
+* [OopsSec Store (OSS)](https://github.com/kOaDT/oss-oopssec-store) - An intentionally vulnerable e-commerce web application for CTF use.
 
 ## Platforms to learn cyber security
 


### PR DESCRIPTION
Hi! I'm the maintainer of OopsSec Store and I'd like to add it to this list.

It's an intentionally vulnerable e-commerce app built with Next.js/React for security training. It includes OWASP Top 10 vulnerabilities, API security issues, and CTF challenges. I think it could be useful for people learning web security, similar to Juice Shop or WebGoat that are already here.

I'm adding it because I believe it's a good resource for the community and I'd like to help others discover it. Feel free to check it out and let me know if you have any questions!

Repo: https://github.com/kOaDT/oss-oopssec-store