### PR TITLE
Add defend.network to Threat databases and alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated list of cyber security resources and tools.
 * [Intelligence X](https://intelx.io/) - Intelligence X is a search engine and data archive. The company is based in Prague, Czech Republic. Its mission is to develop and maintain the search engine and data archive.
 * [Pharos AI](https://conflicts.app) - Open-source real-time OSINT dashboard for geopolitical conflict tracking with interactive geospatial visualization, 30+ news feeds, and actor dossiers.
 * [Stellastra TLS Cipher Suite Database](https://stellastra.com/cipher-suite) - List of hundreds of TLS cipher suites alongside their security rating and vulnerability/deprecation status.
+* [defend.network](https://defend.network) - Free AI-powered daily threat briefings and weekly vulnerability reports structured by threat type, industry, and severity, with action checklists and remediation guidance. Sources include CISA advisories and leading cybersecurity publications.
 
 ## Security advice and guidance
 


### PR DESCRIPTION
Add defend.network to Threat databases and alerts

defend.network publishes free daily AI-generated threat briefings and weekly vulnerability reports for security teams.

Each briefing is structured by threat type (16 categories), affected industry (13 categories), and severity level, with specific action checklists and remediation guidance.

Sources include CISA advisories, vendor bulletins, and leading cybersecurity publications including The Hacker News, BleepingComputer, Krebs on Security, Dark Reading, and The Record.

- Completely free, no signup required
- RSS feed available at https://defend.network/feed.xml
- 29 category pages for browsing by threat type or industry
- Weekly vulnerability reports with patch priority matrices

https://defend.network