### PR TITLE
Add AdversaryGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A curated list of cyber security resources and tools.
 
 * [ATT&CK](https://attack.mitre.org/) - ATT&CK is a knowledge base of cyber adversary behavior and taxonomy for adversarial actions across their lifecycle. ATT&CK has two parts: ATT&CK for Enterprise, which covers behavior against enterprise IT networks and cloud, and ATT&CK for Mobile, which focuses on behavior against mobile devices.
 
+* [AdversaryGraph](https://github.com/anpa1200/adversarygraph) - Self-hosted CTI-to-detection platform for ATT&CK/ATLAS mapping, IOC enrichment, TTP comparison, and analyst reporting.
+
 * [NHS Digital Cyber Alerts](https://digital.nhs.uk/cyber-alerts) - We issue cyber security alert notifications to health and care organisations, ranging from weekly threat bulletins to immediate high-severity alerts.
 
 * [cve-search](https://cve.circl.lu/) - cve-search is accessible via a web interface and an HTTP API. cve-search is an interface to search publicly known information from security vulnerabilities in software and hardware along with their corresponding exposures.


### PR DESCRIPTION
Adds AdversaryGraph to the threat databases and alerts section.

AdversaryGraph is a self-hosted CTI-to-detection platform for ATT&CK/ATLAS mapping, IOC enrichment, TTP comparison, and analyst reporting.

Validation: git diff --check.