### PR TITLE
Add ARS3NAL - offline pentest & bug-bounty arsenal

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ A curated list of cyber security resources and tools.
 * [vnaya - Cybersecurity For Your Kids](https://www.vnaya.com/these-top-educational-cyber-security-resources-will-help-your-kids-to-stay-safe-from-cyber-crime/) - These Top Educational Cyber Security Resources Will Help Your Kids To Stay Safe From Cyber Crime.
 * [Gracker AI](https://gracker.ai/) - AI Cybersecurity Marketing Tool
 * [Watchtower](https://github.com/fzn0x/watchtower) - AI Pentesting Framework Automation Tool
+* [ARS3NAL](https://github.com/inflictx/Arsenal) - Offline-first, searchable arsenal of pentest & bug bounty resources: ~1500 payloads, command generator, GTFOBins, wordlists, embedded CyberChef, reverse shells and 70 checklists.
 
 ## Must Read
 - [RTFM: Red Team Field Manual v2](https://amzn.to/3IZXVj2) by Ben Clark, Nick Downer 


### PR DESCRIPTION
Adds **ARS3NAL** to the list.

ARS3NAL is an offline-first, searchable arsenal for pentesting and bug bounty: ~1500 payloads, a click-to-build command generator, GTFOBins, a wordlists reference, an embedded CyberChef, a reverse-shell generator, 70 interactive checklists and an engagement/findings tracker. It is a self-hosted web app and also ships a static live demo. Open-source, GPL-3.0, bilingual EN/RU.

- Repo: https://github.com/inflictx/Arsenal
- Live demo: https://inflictx.github.io/Arsenal/