### PR TITLE
Add Darkmoon (GPL-3.0 autonomous pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A curated list of cyber security resources and tools.
 - [Ethical Hacking](https://amzn.to/41TLu12) by Daniel G. Graham
 - [Foundations of Information Security](https://amzn.to/41VOPga) by Jason Andress
 - [Penetration Testing](https://amzn.to/3mweg7N) by Georgia Weidman
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPL-3.0) autonomous AI penetration testing platform covering web, API, Active Directory and Kubernetes, orchestrating 80+ offensive tools as an MCP host with proof of exploitation and a local privacy gateway (the LLM never sees real IPs or credentials).
 - [Metasploit](https://amzn.to/3Zq362M) by David Kennedy, Jim O’Gorman, Devon Kearns, and Mati Aharoni
 - [The Tangled Web: A Guide to Securing Modern Web Applications](https://amzn.to/3yhgv14) by Michal Zalewski
   


### PR DESCRIPTION
Hi, and thanks for maintaining this list.

Adding **Darkmoon**, a GPL-3.0 autonomous penetration testing platform. Unlike most tools in this space it covers Active Directory and Kubernetes alongside web and APIs, and its privacy gateway keeps target data (real IPs, hostnames, credentials) away from the LLM. Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: this is our project. Happy to adjust the wording or placement, or to close this if it is not a fit for the list.