### PR TITLE
Add Poszo Next.js Security Headers Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ A curated list of cyber security resources and tools.
 - [Hacking APIs](https://amzn.to/3F3M1Dw) by Corey Ball
 - [Real-World Bug Hunting](https://amzn.to/3ZLqc3F) by Peter Yaworski
 
+## Secure web application tools
+
+* [Poszo Next.js Security Headers Starter](https://github.com/poszothebuilder/poszo-nextjs-security-headers) - MIT-licensed Next.js response-header configurations with CSP guidance, a dependency-free deployed-site checker, and rollback instructions.
+
 ## Secure Software Development (OWASP)
 
 * [OWASP Top 10](https://owasp.org/Top10/) - The most critical security risks to web applications.


### PR DESCRIPTION
## Summary

- add a focused secure web application tools section
- list the free MIT-licensed Poszo Next.js Security Headers Starter
- describe its response-header configuration, CSP guidance, deployed-site checker, and rollback instructions

Poszo maintains the submitted resource.

## Verification

- confirmed there is no existing Poszo or matching Next.js security-headers submission
- confirmed the linked repository is public and MIT licensed
- `git diff --check` passes
- README-only change; no repository code was executed