### PR TITLE
Add NuGuard project to security resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A curated list of cyber security resources and tools.
 * [OWASP WebGoat](https://owasp.org/www-project-webgoat/) - Deliberately insecure web application maintained by OWASP.
 * [OWASP Security Shepherd](https://owasp.org/www-project-security-shepherd/) - Training platform for learning and practicing application security.
 * [OopsSec Store (OSS)](https://github.com/kOaDT/oss-oopssec-store) - An intentionally vulnerable e-commerce web application for CTF use.
+* [NuGuard](https://github.com/NuGuardAI/nuguard) - Open-source CLI that generates an AI-SBOM (AIBOM) and red-teams agentic AI applications for supply-chain and behavioral risks, alongside tools like CycloneDX and OWASP Dependency-Check.
 
 ## Platforms to learn cyber security
 


### PR DESCRIPTION
Adds NuGuard (https://github.com/NuGuardAI/nuguard), an open-source
(Apache-2.0) CLI that:
- Generates an AI-SBOM (AIBOM) from a local codebase or Git repo
- Performs structural/supply-chain risk analysis
- Runs automated red-teaming for prompt injection, tool/MCP misuse, and
  data exfiltration
- Validates AI behavioral policy compliance (static + runtime)
- Exports findings as SARIF/JSON/Markdown with remediation suggestions

Installable via `pip install nuguard`. 