### PR TITLE
Added OWASP VulnReach to OWASP Project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A curated list of cyber security resources and tools.
 * [OWASP WebGoat](https://owasp.org/www-project-webgoat/) - Deliberately insecure web application maintained by OWASP.
 * [OWASP Security Shepherd](https://owasp.org/www-project-security-shepherd/) - Training platform for learning and practicing application security.
 * [OopsSec Store (OSS)](https://github.com/kOaDT/oss-oopssec-store) - An intentionally vulnerable e-commerce web application for CTF use.
+* [OWASP VulnReach](https://github.com/OWASP/VulnReach/) - Adds runtime-aware reachability analysis on top of standard SCA output. Combines static taint tracking, AST call-graph analysis, route exposure mapping, and live runtime coverage to classify each detected CVE as dynamically reachable, statically reachable, uncertain, or not reachable — cutting through SCA noise to surface only the vulnerabilities that actually need fixing.
 
 ## Platforms to learn cyber security
 


### PR DESCRIPTION
Adds [OWASP VulnReach](https://github.com/OWASP/VulnReach/) to the OWASP Project list.

VulnReach adds runtime-aware reachability analysis on top of standard SCA output. It combines static taint tracking, AST call-graph analysis, route exposure mapping, and live runtime coverage to classify each detected CVE as dynamically reachable, statically reachable, uncertain, or not reachable — cutting through SCA noise to surface only the vulnerabilities that actually need fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)